### PR TITLE
fix: increase z-index for overlay and add overflow properties to moda…

### DIFF
--- a/app/components/about/widgets/quote-widget/QuoteWidgetShowcase.module.css
+++ b/app/components/about/widgets/quote-widget/QuoteWidgetShowcase.module.css
@@ -44,12 +44,13 @@
   align-items: center;
   justify-content: center;
   padding: 1rem;
-  z-index: 50;
+  z-index: 1100;
 }
 
 .modal {
   position: relative;
   width: min(640px, 100%);
+  max-height: calc(100vh - 2rem);
   background: #fff;
   border-radius: 20px;
   padding: 2rem 2rem 1.5rem;
@@ -57,6 +58,8 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .closeButton {


### PR DESCRIPTION
# İlgili Issue

Closes #104  

# Özet

Bu PR, quote widget embed modalında responsive kullanım sırasında ortaya çıkan scroll yerleşim problemini giderir.

Mevcut durumda modal içeriği kendi içinde kaydırıldığı için scrollbar, modalın sağ kenarında değil içerik alanının içinde başlıyordu. Bu da özellikle mobil ve dar ekranlarda input alanlarının hizasında istenmeyen bir görünüm oluşturuyordu.

# Yapılan Değişiklikler

- Modal için maksimum yükseklik tanımlandı
- Dikey scroll davranışı içerik bloğundan alınıp doğrudan modal kapsayıcısına taşındı
- Yatay taşma kapatıldı
- Böylece scrollbar, modalın içeriğinde değil doğrudan açılan pencerenin sağ kenarında görünür hale geldi

# Beklenen Sonuç

- Responsive görünümde modal ekranı taşırmaz
- İçerik gerektiğinde kaydırılabilir kalır
- Scrollbar, input alanlarının yanında değil modalın sağ tarafında görünür

# Test

- `npm run build`
